### PR TITLE
Password reset

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -12,3 +12,11 @@ export const loginUser = async (user) => {
 export const updateUser = async (user) => {
     return (await axios.put(hostUrl + '/auth/update', user, defaultHeader())).data;
 };
+
+export const forgotPassword = async (email) => {
+    return (await axios.post(hostUrl + '/auth/forgot_password', { email })).data;
+};
+
+export const resetPassword = async (token, password) => {
+    return (await axios.post(hostUrl + '/auth/reset_password', { token, password })).data;
+};

--- a/frontend/src/pages/ForgotPassword/index.js
+++ b/frontend/src/pages/ForgotPassword/index.js
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Button, Form } from 'react-bootstrap';
+import { useBreadcrumbContext } from 'AppContext';
+import { Formik } from 'formik';
+import { loginUrl } from 'utilities/appUrls';
+import { forgotPassword } from 'api/auth';
+import * as yup from 'yup';
+
+const ForgotPassword = () => {
+    const { setBreadcrumb } = useBreadcrumbContext();
+
+    const history = useHistory();
+
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        setBreadcrumb("FORGOT PASSWORD", []);
+        // eslint-disable-next-line
+    }, [])
+
+    const schema = yup.object().shape({
+        email: yup.string()
+            .email("*Email must be valid")
+            .max(100, "*Email can't be longer than 100 characters")
+            .required("*Email is required")
+    });
+
+    const handleSubmit = async (data) => {
+        setLoading(true);
+        try {
+            const message = await forgotPassword(data.email);
+            setLoading(false);
+            history.push({
+                pathname: loginUrl,
+                state: { message }
+            });
+        } catch (e) {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <>
+            <div className="tab-container">
+                <div className="tab-title">
+                    FORGOT PASSWORD
+                </div>
+                <div className="tab-content">
+                    <Formik
+                        validationSchema={schema}
+                        initialValues={{ email: "" }}
+                        onSubmit={handleSubmit}
+                    >
+                        {({
+                            handleSubmit,
+                            handleChange,
+                            touched,
+                            errors,
+                        }) => (
+                                <Form noValidate onSubmit={handleSubmit}>
+                                    <Form.Text style={{ textAlign: 'left', color: 'var(--text-secondary)', margin: '20px 0' }} className="font-18">
+                                        Lost your password? Please enter your email address. You will receive a link to create a new password via email.
+                                    </Form.Text>
+
+                                    <Form.Group style={{ marginTop: 40 }}>
+                                        <Form.Label>Enter Email</Form.Label>
+                                        <Form.Control
+                                            className="form-control-gray"
+                                            size="xl-18"
+                                            type="email"
+                                            name="email"
+                                            maxLength={100}
+                                            defaultValue=""
+                                            onChange={handleChange}
+                                            isInvalid={touched.email && errors.email}
+                                        />
+                                        <Form.Control.Feedback type="invalid">
+                                            {errors.email}
+                                        </Form.Control.Feedback>
+                                    </Form.Group>
+
+                                    <Button
+                                        size="xxl"
+                                        style={{ margin: '60px 0' }}
+                                        block
+                                        disabled={loading}
+                                        type="submit"
+                                        variant="transparent-black-shadow"
+                                    >
+                                        SUBMIT
+                                    </Button>
+                                </Form>
+                            )}
+                    </Formik>
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default ForgotPassword;

--- a/frontend/src/pages/Login/index.js
+++ b/frontend/src/pages/Login/index.js
@@ -6,7 +6,7 @@ import { setSession, setRememberInfo, getRememberInfo, removeRememberInfo } from
 import { SiFacebook, SiGmail } from 'react-icons/si';
 import { loginUser } from 'api/auth';
 import { forgotPasswordUrl, registerUrl } from 'utilities/appUrls';
-import { useBreadcrumbContext, useUserContext } from 'AppContext';
+import { useAlertContext, useBreadcrumbContext, useUserContext } from 'AppContext';
 import * as yup from 'yup';
 
 import './login.css';
@@ -14,6 +14,7 @@ import './login.css';
 const Login = () => {
     const { setBreadcrumb } = useBreadcrumbContext();
     const { setLoggedIn } = useUserContext();
+    const { showMessage } = useAlertContext();
     const history = useHistory();
 
     const rememberInfo = getRememberInfo();
@@ -23,6 +24,9 @@ const Login = () => {
 
     useEffect(() => {
         setBreadcrumb("LOGIN", []);
+        const message = history.location.state != null && history.location.state.message;
+        if (message)
+            showMessage("success", message);
         // eslint-disable-next-line
     }, [])
 

--- a/frontend/src/pages/ResetPassword/index.js
+++ b/frontend/src/pages/ResetPassword/index.js
@@ -1,0 +1,126 @@
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Button, Form } from 'react-bootstrap';
+import { useBreadcrumbContext } from 'AppContext';
+import { Formik } from 'formik';
+import { loginUrl } from 'utilities/appUrls';
+import { resetPassword } from 'api/auth';
+import * as qs from 'query-string';
+import * as yup from 'yup';
+
+const ResetPassword = () => {
+    const { setBreadcrumb } = useBreadcrumbContext();
+
+    const history = useHistory();
+    const urlParams = qs.parse(history.location.search);
+
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        setBreadcrumb("RESET PASSWORD", []);
+        // eslint-disable-next-line
+    }, [])
+
+    const schema = yup.object().shape({
+        password: yup.string()
+            .required("*Password is required")
+            .min(8, "*Password must have at least 8 characters")
+            .max(255, "*Password can't be longer than 255 characters"),
+        confirmPassword: yup.string()
+            .required("*Confirm your password")
+            .oneOf([yup.ref("password")], "*Passwords must match")
+            .min(8, "*Password must have at least 8 characters")
+            .max(255, "*Password can't be longer than 255 characters"),
+    });
+
+    const handleSubmit = async (data) => {
+        setLoading(true);
+        try {
+            const message = await resetPassword(urlParams.token, data.password);
+            setLoading(false);
+            history.push({
+                pathname: loginUrl,
+                state: { message }
+            });
+        } catch (e) {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <>
+            <div className="tab-container">
+                <div className="tab-title">
+                    RESET PASSWORD
+                </div>
+                <div className="tab-content">
+                    <Formik
+                        validationSchema={schema}
+                        initialValues={{ password: "", confirmPassword: "" }}
+                        onSubmit={handleSubmit}
+                    >
+                        {({
+                            handleSubmit,
+                            handleChange,
+                            touched,
+                            errors,
+                        }) => (
+                                <Form noValidate onSubmit={handleSubmit}>
+                                    <Form.Text style={{ textAlign: 'left', color: 'var(--text-secondary)', margin: '20px 0' }} className="font-18">
+                                        Enter a new password below.
+                                    </Form.Text>
+
+                                    <Form.Group style={{ marginTop: 40 }}>
+                                        <Form.Label>Password</Form.Label>
+                                        <Form.Control
+                                            className="form-control-gray"
+                                            size="xl-18"
+                                            type="password"
+                                            name="password"
+                                            maxLength={255}
+                                            defaultValue=""
+                                            onChange={handleChange}
+                                            isInvalid={touched.password && errors.password}
+                                        />
+                                        <Form.Control.Feedback type="invalid">
+                                            {errors.password}
+                                        </Form.Control.Feedback>
+                                    </Form.Group>
+
+                                    <Form.Group style={{ marginTop: 20 }}>
+                                        <Form.Label>Confirm Password</Form.Label>
+                                        <Form.Control
+                                            className="form-control-gray"
+                                            size="xl-18"
+                                            type="password"
+                                            name="confirmPassword"
+                                            maxLength={255}
+                                            defaultValue=""
+                                            onChange={handleChange}
+                                            isInvalid={touched.confirmPassword && errors.confirmPassword}
+                                        />
+                                        <Form.Control.Feedback type="invalid">
+                                            {errors.confirmPassword}
+                                        </Form.Control.Feedback>
+                                    </Form.Group>
+
+                                    <Button
+                                        size="xxl"
+                                        style={{ margin: '60px 0' }}
+                                        block
+                                        disabled={loading}
+                                        type="submit"
+                                        variant="transparent-black-shadow"
+                                    >
+                                        SUBMIT
+                                    </Button>
+                                </Form>
+                            )}
+                    </Formik>
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default ResetPassword;

--- a/frontend/src/routing/MyRoutes.js
+++ b/frontend/src/routing/MyRoutes.js
@@ -9,6 +9,8 @@ import Shop from 'pages/Shop';
 import ItemPage from 'pages/ItemPage';
 import Login from 'pages/Login';
 import Register from 'pages/Register';
+import ForgotPassword from 'pages/ForgotPassword';
+import ResetPassword from 'pages/ResetPassword';
 import Sell from 'pages/Sell';
 import MyAccount from 'pages/MyAccount';
 import PageNotFound from 'pages/PageNotFound';
@@ -22,6 +24,8 @@ const MyRoutes = () => {
             <Route path="/shop*" component={Shop} />
             <GuestRoute path="/login" component={Login} />
             <GuestRoute path="/register" component={Register} />
+            <GuestRoute path="/forgot_password" component={ForgotPassword} />
+            <GuestRoute path="/reset_password" component={ResetPassword} />
             <PrivateRoute path="/my_account/seller/sell" component={Sell} />
             <PrivateRoute path="/my_account" component={MyAccount} />
             <Route component={PageNotFound} />

--- a/frontend/src/shared/Header/index.js
+++ b/frontend/src/shared/Header/index.js
@@ -5,7 +5,7 @@ import { GrFormSearch } from "react-icons/gr";
 import { FormControl, Image, ListGroup, Nav, Navbar } from 'react-bootstrap';
 import { Link, NavLink, useHistory } from 'react-router-dom';
 import { removeSession, getUser } from 'utilities/localStorage';
-import { homeUrl, loginUrl, myAccountUrl, registerUrl, shopUrl, myAccountSellerUrl, myAccountBidsUrl, myAccountWishlistUrl, myAccountSettingsUrl } from 'utilities/appUrls';
+import { homeUrl, loginUrl, myAccountUrl, registerUrl, shopUrl, myAccountSellerUrl, myAccountBidsUrl, myAccountWishlistUrl, myAccountSettingsUrl, forgotPasswordUrl, resetPasswordUrl } from 'utilities/appUrls';
 import { useUserContext } from 'AppContext';
 import * as qs from 'query-string';
 
@@ -106,7 +106,8 @@ const Header = () => {
                 </div>
                 <Nav style={{ position: 'relative' }}>
                     <NavLink
-                        isActive={(match, location) => (match.isExact || location.pathname === loginUrl || location.pathname === registerUrl)}
+                        isActive={(match, location) => (match.isExact || location.pathname === loginUrl || location.pathname === registerUrl ||
+                            location.pathname === forgotPasswordUrl || location.pathname === resetPasswordUrl)}
                         className="black-nav-link nav-link"
                         activeClassName="black-active-nav-link"
                         to={homeUrl}

--- a/frontend/src/utilities/appUrls.js
+++ b/frontend/src/utilities/appUrls.js
@@ -9,6 +9,7 @@ export const myAccountBidsUrl = "/my_account/bids";
 export const myAccountWishlistUrl = "/my_account/wishlist";
 export const myAccountSettingsUrl = "/my_account/settings";
 export const forgotPasswordUrl = "/forgot_password";
+export const resetPasswordUrl = "/reset_password";
 
 export const allCategoryUrl = "/all";
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>mail</artifactId>
+			<version>1.5.0-b01</version>
+		</dependency>
+		<dependency>
 			<groupId>com.atlascopco</groupId>
 			<artifactId>hunspell-bridj</artifactId>
 			<version>1.0.4</version>

--- a/src/main/java/ba/atlantbh/auctionapp/controllers/PersonController.java
+++ b/src/main/java/ba/atlantbh/auctionapp/controllers/PersonController.java
@@ -1,9 +1,11 @@
 package ba.atlantbh.auctionapp.controllers;
 
+import ba.atlantbh.auctionapp.exceptions.BadGatewayException;
 import ba.atlantbh.auctionapp.exceptions.BadRequestException;
 import ba.atlantbh.auctionapp.exceptions.ConflictException;
 import ba.atlantbh.auctionapp.exceptions.UnauthorizedException;
 import ba.atlantbh.auctionapp.models.Person;
+import ba.atlantbh.auctionapp.requests.ForgotPassRequest;
 import ba.atlantbh.auctionapp.requests.LoginRequest;
 import ba.atlantbh.auctionapp.requests.RegisterRequest;
 import ba.atlantbh.auctionapp.requests.UpdateProfileRequest;
@@ -56,5 +58,14 @@ public class PersonController {
     })
     public ResponseEntity<Person> update(@RequestBody @Valid UpdateProfileRequest updateProfileRequest) {
         return ResponseEntity.ok(personService.update(updateProfileRequest));
+    }
+
+    @PostMapping("/forgot_password")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Bad request", response = BadRequestException.class),
+            @ApiResponse(code = 502, message = "Bad gateway", response = BadGatewayException.class),
+    })
+    public ResponseEntity<String> forgotPassword(@RequestBody @Valid ForgotPassRequest forgotPassRequest) {
+        return ResponseEntity.ok(personService.forgotPassword(forgotPassRequest));
     }
 }

--- a/src/main/java/ba/atlantbh/auctionapp/controllers/PersonController.java
+++ b/src/main/java/ba/atlantbh/auctionapp/controllers/PersonController.java
@@ -5,10 +5,7 @@ import ba.atlantbh.auctionapp.exceptions.BadRequestException;
 import ba.atlantbh.auctionapp.exceptions.ConflictException;
 import ba.atlantbh.auctionapp.exceptions.UnauthorizedException;
 import ba.atlantbh.auctionapp.models.Person;
-import ba.atlantbh.auctionapp.requests.ForgotPassRequest;
-import ba.atlantbh.auctionapp.requests.LoginRequest;
-import ba.atlantbh.auctionapp.requests.RegisterRequest;
-import ba.atlantbh.auctionapp.requests.UpdateProfileRequest;
+import ba.atlantbh.auctionapp.requests.*;
 import ba.atlantbh.auctionapp.responses.LoginResponse;
 import ba.atlantbh.auctionapp.responses.RegisterResponse;
 import ba.atlantbh.auctionapp.security.JwtTokenUtil;
@@ -67,5 +64,13 @@ public class PersonController {
     })
     public ResponseEntity<String> forgotPassword(@RequestBody @Valid ForgotPassRequest forgotPassRequest) {
         return ResponseEntity.ok(personService.forgotPassword(forgotPassRequest));
+    }
+
+    @PostMapping("/reset_password")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Bad request", response = BadRequestException.class),
+    })
+    public ResponseEntity<String> resetPassword(@RequestBody @Valid ResetPassRequest resetPassRequest) {
+        return ResponseEntity.ok(personService.resetPassword(resetPassRequest));
     }
 }

--- a/src/main/java/ba/atlantbh/auctionapp/exceptions/BadGatewayException.java
+++ b/src/main/java/ba/atlantbh/auctionapp/exceptions/BadGatewayException.java
@@ -1,0 +1,12 @@
+package ba.atlantbh.auctionapp.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_GATEWAY)
+public class BadGatewayException extends RuntimeException {
+
+    public BadGatewayException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ba/atlantbh/auctionapp/exceptions/RestExceptionHandler.java
+++ b/src/main/java/ba/atlantbh/auctionapp/exceptions/RestExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -32,6 +33,13 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
         CustomExceptionResponse body = getDefaultExceptionBody(status, request);
         body.setMessage(ex.getMessage());
+        return new ResponseEntity<>(body, headers, status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        CustomExceptionResponse body = getDefaultExceptionBody(status, request);
+        body.setMessage("JSON parse error");
         return new ResponseEntity<>(body, headers, status);
     }
 

--- a/src/main/java/ba/atlantbh/auctionapp/models/Token.java
+++ b/src/main/java/ba/atlantbh/auctionapp/models/Token.java
@@ -28,6 +28,9 @@ public class Token {
     @Column(nullable = false)
     private UUID token;
 
+    @Column(nullable = false)
+    private Boolean used = false;
+
     @ManyToOne
     @JoinColumn(name = "person_id", nullable = false)
     private Person person;

--- a/src/main/java/ba/atlantbh/auctionapp/models/Token.java
+++ b/src/main/java/ba/atlantbh/auctionapp/models/Token.java
@@ -1,0 +1,39 @@
+package ba.atlantbh.auctionapp.models;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class Token {
+    @Id
+    @Type(type = "uuid-char")
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    private UUID id;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime dateCreated;
+
+    @Type(type = "uuid-char")
+    @Column(nullable = false)
+    private UUID token;
+
+    @ManyToOne
+    @JoinColumn(name = "person_id", nullable = false)
+    private Person person;
+
+    public Token(UUID token, Person person) {
+        this.token = token;
+        this.person = person;
+    }
+}

--- a/src/main/java/ba/atlantbh/auctionapp/repositories/TokenRepository.java
+++ b/src/main/java/ba/atlantbh/auctionapp/repositories/TokenRepository.java
@@ -1,0 +1,9 @@
+package ba.atlantbh.auctionapp.repositories;
+
+import ba.atlantbh.auctionapp.models.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TokenRepository extends JpaRepository<Token, UUID> {
+}

--- a/src/main/java/ba/atlantbh/auctionapp/repositories/TokenRepository.java
+++ b/src/main/java/ba/atlantbh/auctionapp/repositories/TokenRepository.java
@@ -2,8 +2,20 @@ package ba.atlantbh.auctionapp.repositories;
 
 import ba.atlantbh.auctionapp.models.Token;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface TokenRepository extends JpaRepository<Token, UUID> {
+
+    @Query(value = "SELECT * FROM token t WHERE t.token = :query " +
+            "AND now() <= (date_created + INTERVAL '24 hour') AND NOT used",
+            nativeQuery = true)
+    Optional<Token> getToken(String query);
+
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM token t WHERE person_id = :personId " +
+            "AND now() <= (date_created + INTERVAL '24 hour') AND NOT used)",
+            nativeQuery = true)
+    Boolean existsByPerson(String personId);
 }

--- a/src/main/java/ba/atlantbh/auctionapp/requests/ForgotPassRequest.java
+++ b/src/main/java/ba/atlantbh/auctionapp/requests/ForgotPassRequest.java
@@ -1,0 +1,20 @@
+package ba.atlantbh.auctionapp.requests;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ForgotPassRequest {
+
+    @NotBlank(message = "Email can't be blank")
+    @Email(message = "Wrong email format")
+    @Size(max = 100, message = "Email can't be longer than 100 characters")
+    private String email;
+}

--- a/src/main/java/ba/atlantbh/auctionapp/requests/ResetPassRequest.java
+++ b/src/main/java/ba/atlantbh/auctionapp/requests/ResetPassRequest.java
@@ -1,0 +1,24 @@
+package ba.atlantbh.auctionapp.requests;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResetPassRequest {
+
+    @NotNull(message = "Token is required")
+    private UUID token;
+
+    @NotBlank(message = "Password can't be blank")
+    @Size(min = 8, message = "Password must have at least 8 characters")
+    @Size(max = 255, message = "Password can't be longer than 255 characters")
+    private String password;
+}

--- a/src/main/java/ba/atlantbh/auctionapp/services/EmailService.java
+++ b/src/main/java/ba/atlantbh/auctionapp/services/EmailService.java
@@ -1,0 +1,59 @@
+package ba.atlantbh.auctionapp.services;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.mail.*;
+import javax.mail.internet.*;
+import java.util.Properties;
+
+@Service
+public class EmailService {
+
+    private final String host = "smtp.gmail.com";
+    private final int port = 587;
+    private String username;
+    private String password;
+
+    @Value("${app.emailUsername}")
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Value("${app.emailPassword}")
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void sendMail(String recipientEmail, String subject, String body) throws MessagingException {
+        Properties prop = new Properties();
+        prop.put("mail.smtp.auth", "true");
+        prop.put("mail.smtp.starttls.enable", "true");
+        prop.put("mail.smtp.host", host);
+        prop.put("mail.smtp.port", port);
+        prop.put("mail.smtp.ssl.trust", host);
+
+        Session session = Session.getInstance(prop, new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(username, password);
+            }
+        });
+
+        Message message = new MimeMessage(session);
+        message.setFrom(new InternetAddress(username));
+        message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(recipientEmail));
+        message.setSubject(subject);
+
+        MimeBodyPart mimeBodyPart = new MimeBodyPart();
+        mimeBodyPart.setContent(body, "text/html");
+
+        Multipart multipart = new MimeMultipart();
+        multipart.addBodyPart(mimeBodyPart);
+
+        message.setContent(multipart);
+        Transport.send(message);
+
+    }
+
+}

--- a/src/main/java/ba/atlantbh/auctionapp/services/PersonService.java
+++ b/src/main/java/ba/atlantbh/auctionapp/services/PersonService.java
@@ -115,18 +115,19 @@ public class PersonService {
     }
 
     public String forgotPassword(ForgotPassRequest forgotPassRequest) {
-        String message = "We sent you an email with a confirmation link. " +
-                "It will be active in the next 24 hours.";
+        String message = "We sent you an email with a link to reset your password. " +
+                "The link will expire after 24 hours.";
         Optional<Person> personOptional = personRepository.findByEmail(forgotPassRequest.getEmail());
         if (personOptional.isEmpty())
             return message;
         Person person = personOptional.get();
         if (tokenRepository.existsByPerson(person.getId().toString()))
-            return "We have already sent you an email in the last 24 hours. Check your inbox.";
+            return "We have already sent you an email with a link to reset your password " +
+                    "in the last 24 hours. Please check your inbox.";
         UUID uuid = UUID.randomUUID();
         String body = formEmailBody(hostUrl, uuid);
         try {
-            emailService.sendMail(person.getEmail(), "Forgot password", body);
+            emailService.sendMail(person.getEmail(), "Password reset", body);
         } catch (MessagingException e) {
             throw new BadGatewayException("We have issues sending you an email");
         }

--- a/src/main/java/ba/atlantbh/auctionapp/utilities/ResourceUtil.java
+++ b/src/main/java/ba/atlantbh/auctionapp/utilities/ResourceUtil.java
@@ -1,0 +1,25 @@
+package ba.atlantbh.auctionapp.utilities;
+
+import ba.atlantbh.auctionapp.services.PersonService;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+public class ResourceUtil {
+    public static String getResourceFileAsString(String fileName) {
+        InputStream is = getResourceFileAsInputStream(fileName);
+        if (is != null) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        } else {
+            throw new RuntimeException("Resource not found");
+        }
+    }
+
+    public static InputStream getResourceFileAsInputStream(String fileName) {
+        ClassLoader classLoader = PersonService.class.getClassLoader();
+        return classLoader.getResourceAsStream(fileName);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
 app:
   jwtSecret: ${JWT_SECRET}
   jwtExpirationInMs: ${JWT_EXPIRATION}
+  emailUsername: ${EMAIL_USERNAME}
+  emailPassword: ${EMAIL_PASSWORD}
+  hostUrl: ${HOST_URL}
 server:
   error:
     include-message: always

--- a/src/main/resources/static/mail.html
+++ b/src/main/resources/static/mail.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+    <title>Reset Password</title>
+    <meta name="description" content="Reset Password">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@100;300;400;700&display=swap" rel="stylesheet">
+    <style type="text/css">
+        body {
+            margin: 0;
+            font-family: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            background-color: #FAFAFA;
+        }
+        a:hover {
+            text-decoration: none;
+        }
+    </style>
+</head>
+
+<body>
+<table cellspacing="0" border="0" cellpadding="0" width="100%" bgcolor="#FAFAFA">
+    <tr>
+        <td>
+            <table style="background-color: #FAFAFA; max-width:670px;  margin:0 auto;"
+                   width="100%" border="0"
+                   align="center" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td style="height:80px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="text-align:center;">
+                        <a rel="noopener noreferrer" target="_blank"
+                           href="https://auction-app.netlify.app">
+                            <img style="margin-right: 5px; vertical-align: text-bottom;"
+                                 src="https://i.imgur.com/9dfOjDG.png" alt="logo">
+                        </a>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="height:20px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td>
+                        <table width="95%" border="0" align="center" cellpadding="0" cellspacing="0"
+                               style="max-width:670px;background:#fff; border-radius:3px; text-align:center;-webkit-box-shadow:0 6px 18px 0 rgba(0,0,0,.06);-moz-box-shadow:0 6px 18px 0 rgba(0,0,0,.06);box-shadow:0 6px 18px 0 rgba(0,0,0,.06);">
+                            <tr>
+                                <td style="height:40px;">&nbsp;</td>
+                            </tr>
+                            <tr>
+                                <td style="padding:0 35px;">
+                                    <h1 style="color:#1e1e2d; font-weight:500; margin:0;font-size:32px;letter-spacing: 1.26px;">
+                                        You have
+                                        requested to reset your password</h1>
+                                    <span
+                                            style="display:inline-block; vertical-align:middle; margin:29px 0 26px; border-bottom:1px solid #cecece; width:100px;"></span>
+                                    <p style="color:#455056; font-size:16px;line-height:24px; margin:0; letter-spacing: 0.56px;">
+                                        We cannot simply send you your old password. A unique link to reset your
+                                        password has been generated for you. To reset your password, click the
+                                        following link and follow the instructions.
+                                    </p>
+                                    <a href="hostUrl"
+                                       style="background:#8367D8;text-decoration:none; font-weight:700; margin-top:35px; color:#fff;text-transform:uppercase;border: 3px solid #8367D8; font-size:16px; letter-spacing: 0.63px;padding:10px 24px;display:inline-block;">Reset
+                                        Password</a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="height:40px;">&nbsp;</td>
+                            </tr>
+                        </table>
+                    </td>
+                <tr>
+                    <td style="height:20px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="text-align:center;">
+                        <p style="font-size:14px; color:rgba(69, 80, 86, 0.7411764705882353); line-height:28px; margin:0 0 0;letter-spacing: 0.49px;">
+                            You received this email because you requested a password reset.
+                            <br/>
+                            If you did not, please <a
+                                href="mailto:auctionapp.atlantbh@gmail.com" target="_blank"
+                                style="color: #8367D8;text-decoration: none; font-weight: 700;">contact us.</a></p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="height:40px;">&nbsp;</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+
+</html>


### PR DESCRIPTION
- 2 new backend routes have been added:
    - /auth/forgot_password - users first send a request with an email to this endpoint which sends a token to the supplied email in form of a password reset link
That link has the following form: _host_url + /reset_password + token_ (as parameter)
*You can always visit _host_url + /reset_password_ on frontend, but it's of no use if a valid token isn't in the url.
    - /auth/reset_password - password update is done with this route, a valid token and a new password must be supplied

The mail you get is in the following form:
<img src="https://i.imgur.com/nS4dVew.png" width="450" title="Email form" alt="Email form">

This branch is currently deployed:
Frontend: https://auction-app.netlify.app
Backend: https://auction-atlant-app.herokuapp.com