### PR TITLE
Personal suggestions

### DIFF
--- a/frontend/src/api/common.js
+++ b/frontend/src/api/common.js
@@ -5,9 +5,12 @@ export const uploadPreset = process.env.REACT_APP_UPLOAD_PRESET;
 export const cloudName = process.env.REACT_APP_CLOUD_NAME;
 
 export const defaultHeader = () => {
+    const token = getToken();
+    if (token === null)
+        return null;
     return {
         headers: {
-            'Authorization': 'Bearer ' + getToken()
+            'Authorization': 'Bearer ' + token
         }
     };
 }

--- a/frontend/src/api/product.js
+++ b/frontend/src/api/product.js
@@ -6,8 +6,8 @@ export const getProduct = async (productId, userId) => {
     return (await axios.get(hostUrl + '/products', getParams({ productId, userId }))).data;
 };
 
-export const getFeaturedRandomProducts = async () => {
-    return (await axios.get(hostUrl + '/products/featured/random')).data;
+export const getFeaturedProducts = async () => {
+    return (await axios.get(hostUrl + '/products/featured', defaultHeader())).data;
 };
 
 export const getNewProducts = async () => {

--- a/frontend/src/api/subcategory.js
+++ b/frontend/src/api/subcategory.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { getParams, hostUrl } from './common';
+import { getParams, hostUrl, defaultHeader } from './common';
 
-export const getRandomSubcategories = async () => {
-    return (await axios.get(hostUrl + '/subcategories/random')).data;
+export const getFeaturedSubcategories = async () => {
+    return (await axios.get(hostUrl + '/subcategories/featured', defaultHeader())).data;
 };
 
 export const getSubcategoriesForCategory = async (id) => {

--- a/frontend/src/pages/LandingPage/index.js
+++ b/frontend/src/pages/LandingPage/index.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Image, ListGroup } from 'react-bootstrap';
 import { useHistory } from 'react-router-dom';
-import { getFeaturedRandomProducts, getNewProducts, getLastProducts } from 'api/product';
-import { getRandomSubcategories } from 'api/subcategory';
+import { getFeaturedProducts, getNewProducts, getLastProducts } from 'api/product';
+import { getFeaturedSubcategories } from 'api/subcategory';
 import { getCategories } from 'api/category';
 import { IoIosArrowForward } from "react-icons/io";
 import { categoryUrl, allCategoryUrl, subcategoryUrl, productUrl } from "utilities/appUrls";
@@ -17,7 +17,7 @@ const LandingPage = () => {
 
   const [categories, setCategories] = useState([]);
   const [featuredProducts, setFeaturedProducts] = useState([]);
-  const [randomSubcategories, setRandomSubcategories] = useState([]);
+  const [featuredSubcategories, setFeaturedSubcategories] = useState([]);
   const [newAndLastProducts, setNewAndLastProducts] = useState([]);
   const [activePage, setActivePage] = useState(0);
 
@@ -26,8 +26,8 @@ const LandingPage = () => {
     const fetchData = async () => {
       try {
         setCategories(await getCategories());
-        setFeaturedProducts(await getFeaturedRandomProducts());
-        setRandomSubcategories(await getRandomSubcategories());
+        setFeaturedProducts(await getFeaturedProducts());
+        setFeaturedSubcategories(await getFeaturedSubcategories());
         const newProducts = await getNewProducts();
         const lastProducts = await getLastProducts();
         setNewAndLastProducts([newProducts, lastProducts]);
@@ -93,7 +93,7 @@ const LandingPage = () => {
       	</h2>
         <div className="gray-line" />
         <div className="featured-items-container">
-          {randomSubcategories.map(subcategory => (
+          {featuredSubcategories.map(subcategory => (
             <ImageCard key={subcategory.id} data={subcategory} size="xxl" url={subcategoryUrl(subcategory)} fromLandingPage={true} />
           ))}
         </div>

--- a/src/main/java/ba/atlantbh/auctionapp/controllers/ProductController.java
+++ b/src/main/java/ba/atlantbh/auctionapp/controllers/ProductController.java
@@ -29,9 +29,9 @@ public class ProductController {
 
     private final ProductService productService;
 
-    @GetMapping("/featured/random")
-    public ResponseEntity<List<SimpleProductProj>> getFeaturedRandomProducts() {
-        return ResponseEntity.ok(productService.getFeaturedRandomProducts());
+    @GetMapping("/featured")
+    public ResponseEntity<List<SimpleProductProj>> getFeaturedProducts() {
+        return ResponseEntity.ok(productService.getFeaturedProducts());
     }
 
     @GetMapping("/new")

--- a/src/main/java/ba/atlantbh/auctionapp/controllers/SubcategoryController.java
+++ b/src/main/java/ba/atlantbh/auctionapp/controllers/SubcategoryController.java
@@ -23,9 +23,9 @@ public class SubcategoryController {
 
     private final SubcategoryService subcategoryService;
 
-    @GetMapping("/random")
-    public ResponseEntity<List<SubcategoryProj>> getRandomSubcategories() {
-        return ResponseEntity.ok(subcategoryService.getRandomSubcategories());
+    @GetMapping("/featured")
+    public ResponseEntity<List<SubcategoryProj>> getFeaturedSubcategories() {
+        return ResponseEntity.ok(subcategoryService.getFeaturedSubcategories());
     }
 
     @GetMapping("/category")

--- a/src/main/java/ba/atlantbh/auctionapp/repositories/ProductRepository.java
+++ b/src/main/java/ba/atlantbh/auctionapp/repositories/ProductRepository.java
@@ -15,13 +15,15 @@ import java.util.UUID;
 
 public interface ProductRepository extends JpaRepository<Product, UUID> {
 
-    @Query(value = "SELECT pr.id, pr.name, pr.start_price startPrice, pr.description, p.url, c.name categoryName, s.name subcategoryName " +
+    @Query(value = "SELECT * FROM (SELECT pr.id, pr.name, pr.start_price startPrice, pr.description, p.url, c.name categoryName, s.name subcategoryName, " +
+                   "(SELECT COUNT(*) FROM bid b INNER JOIN product p2 on p2.id = b.product_id " +
+                   "WHERE b.person_id = :id AND p2.subcategory_id = pr.subcategory_id) count " +
                    "FROM product pr LEFT OUTER JOIN photo p on pr.id = p.product_id " +
                    "INNER JOIN subcategory s on s.id = pr.subcategory_id " +
                    "INNER JOIN category c on c.id = s.category_id " +
                    "WHERE pr.featured = true AND (p.featured = true OR p.featured IS NULL) AND start_date <= now() AND end_date > now() " +
-                   "ORDER BY RANDOM() LIMIT 6", nativeQuery = true)
-    List<SimpleProductProj> getFeaturedRandomProducts();
+                   "ORDER BY count DESC, RANDOM() LIMIT 18) main ORDER BY RANDOM() LIMIT 6", nativeQuery = true)
+    List<SimpleProductProj> getFeaturedProducts(String id);
 
     @Query(value = "SELECT pr.id, pr.name, pr.start_price startPrice, pr.description, p.url, c.name categoryName, s.name subcategoryName " +
                    "FROM product pr LEFT OUTER JOIN photo p on pr.id = p.product_id " +

--- a/src/main/java/ba/atlantbh/auctionapp/repositories/SubcategoryRepository.java
+++ b/src/main/java/ba/atlantbh/auctionapp/repositories/SubcategoryRepository.java
@@ -12,12 +12,15 @@ import java.util.UUID;
 
 public interface SubcategoryRepository extends JpaRepository<Subcategory, UUID> {
 
-    @Query(value = "SELECT sc.id, sc.name, c.name categoryName, sc.photo_url url, min(start_price) startPrice " +
+    @Query(value = "SELECT * FROM (SELECT sc.id, sc.name, c.name categoryName, sc.photo_url url, min(start_price) startPrice, " +
+                   "(SELECT COUNT(*) FROM bid b INNER JOIN product p2 on p2.id = b.product_id " +
+                   "WHERE b.person_id = :id AND p2.subcategory_id = sc.id) count " +
                    "FROM subcategory sc INNER JOIN category c on c.id = sc.category_id " +
                    "INNER JOIN product p on sc.id = p.subcategory_id " +
                    "WHERE p.start_date <= now() AND p.end_date > now() " +
-                   "GROUP BY (sc.id, sc.name, c.name, sc.photo_url) ORDER BY RANDOM() LIMIT 4", nativeQuery = true)
-    List<SubcategoryProj> getRandomSubcategories();
+                   "GROUP BY (sc.id, sc.name, c.name, sc.photo_url) ORDER BY count DESC, RANDOM() LIMIT 12) main " +
+                   "ORDER BY RANDOM() LIMIT 4", nativeQuery = true)
+    List<SubcategoryProj> getFeaturedSubcategories(String id);
 
     List<SimpleSubcategoryProj> findAllByCategory(Category category);
 }

--- a/src/main/java/ba/atlantbh/auctionapp/services/ProductService.java
+++ b/src/main/java/ba/atlantbh/auctionapp/services/ProductService.java
@@ -39,8 +39,13 @@ public class ProductService {
     private final PayPalRepository payPalRepository;
     private final Hunspell speller;
 
-    public List<SimpleProductProj> getFeaturedRandomProducts() {
-        return productRepository.getFeaturedRandomProducts();
+    public List<SimpleProductProj> getFeaturedProducts() {
+        String id = "";
+        try {
+            id = JwtTokenUtil.getRequestPersonId().toString();
+        } catch (UnauthorizedException ignore) {
+        }
+        return productRepository.getFeaturedProducts(id);
     }
 
     public List<SimpleProductProj> getNewProducts() {

--- a/src/main/java/ba/atlantbh/auctionapp/services/ProductService.java
+++ b/src/main/java/ba/atlantbh/auctionapp/services/ProductService.java
@@ -127,7 +127,8 @@ public class ProductService {
         );
 
         String suggestion = getSuggestion(query);
-        if (suggestion.toLowerCase().equals(query.toLowerCase()) || !productRepository.searchExists(query, tsQuery)) {
+        String suggestionTsQuery = formTsQuery(query);
+        if (suggestion.toLowerCase().equals(query.toLowerCase()) || !productRepository.searchExists(suggestion, suggestionTsQuery)) {
             suggestion = query;
         }
 

--- a/src/main/java/ba/atlantbh/auctionapp/services/SubcategoryService.java
+++ b/src/main/java/ba/atlantbh/auctionapp/services/SubcategoryService.java
@@ -1,11 +1,13 @@
 package ba.atlantbh.auctionapp.services;
 
+import ba.atlantbh.auctionapp.exceptions.UnauthorizedException;
 import ba.atlantbh.auctionapp.exceptions.UnprocessableException;
 import ba.atlantbh.auctionapp.models.Category;
 import ba.atlantbh.auctionapp.projections.SimpleSubcategoryProj;
 import ba.atlantbh.auctionapp.projections.SubcategoryProj;
 import ba.atlantbh.auctionapp.repositories.CategoryRepository;
 import ba.atlantbh.auctionapp.repositories.SubcategoryRepository;
+import ba.atlantbh.auctionapp.security.JwtTokenUtil;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,8 +21,13 @@ public class SubcategoryService {
     private final SubcategoryRepository subcategoryRepository;
     private final CategoryRepository categoryRepository;
 
-    public List<SubcategoryProj> getRandomSubcategories() {
-        return subcategoryRepository.getRandomSubcategories();
+    public List<SubcategoryProj> getFeaturedSubcategories() {
+        String id = "";
+        try {
+            id = JwtTokenUtil.getRequestPersonId().toString();
+        } catch (UnauthorizedException ignore) {
+        }
+        return subcategoryRepository.getFeaturedSubcategories(id);
     }
 
     public List<SimpleSubcategoryProj> getSubcategoriesForCategory(String id) {


### PR DESCRIPTION
- 2 backend routes have been updated:
    - /subcategories/random (changed to /subcategories/**featured**) - returns random subcategories if a JWT isn't supplied with the request (works as before). If a JWT is supplied random subcategories are chosen from the top 12 subcategories for that user. Top subcategories are the ones in which the user has made the most bids.
    - /products/featured/random (changed to /products/**featured**) - returns random products if a JWT isn't supplied with the request (works as before). If a JWT is supplied random products are chosen from the top 18 products for that user. Top products are the ones which belong to subcategories in which the user has made the most bids.